### PR TITLE
#17 Reduce CPU usage since iOS 16.1.

### DIFF
--- a/UIPiPView/Classes/UIPiPView.swift
+++ b/UIPiPView/Classes/UIPiPView.swift
@@ -230,9 +230,15 @@ open class UIPiPView: UIView,
     open func pictureInPictureControllerTimeRangeForPlayback(
         _ pictureInPictureController: AVPictureInPictureController
     ) -> CMTimeRange {
-        return CMTimeRange(
-            start: .negativeInfinity,
-            duration: .positiveInfinity
+
+        /// The following code will suppress AVKit (AVTimer work queue).
+        /// see https://github.com/uakihir0/UIPiPView/issues/17
+        return .init(
+            start: .zero,
+            duration: .init(
+                value: 3600 * 24,
+                timescale: 1
+            )
         )
     }
 


### PR DESCRIPTION
fix #17

Fixed a problem with very large CPU usage on iOS 16.1 and later.

@eximpression Thank you very much!
https://github.com/uakihir0/UIPiPView/issues/17#issuecomment-1424135424

Below is an image of CPU usage when using PiP. This test is based on running the examples in this repository; during PiP, the CPU usage includes the cost of rendering the View.

**Before**
<img width="1008" alt="スクリーンショット 2023-02-09 22 37 36" src="https://user-images.githubusercontent.com/1501888/217828564-ce265cd0-6387-43c7-9c03-23fd46ad0df3.png">

**After**
<img width="1069" alt="スクリーンショット 2023-02-09 22 34 11" src="https://user-images.githubusercontent.com/1501888/217828613-e483958b-0ec4-4f32-b6f5-0a1a8fda9c89.png">
